### PR TITLE
Move user session info into Authorization header; remove userid/token args.

### DIFF
--- a/searcch_backend/api/resources/dashboard.py
+++ b/searcch_backend/api/resources/dashboard.py
@@ -1,7 +1,7 @@
 # logic for /rating
 
 from searcch_backend.api.app import db, config_name
-from searcch_backend.api.common.auth import *
+from searcch_backend.api.common.auth import (verify_api_key, verify_token)
 from searcch_backend.models.model import *
 from searcch_backend.models.schema import *
 from flask import abort, jsonify, request, url_for
@@ -20,42 +20,14 @@ class UserDashboardAPI(Resource):
         - reviews and ratings provided by the user
         - past searches made by the user
     """
-    def __init__(self):
-        self.reqparse = reqparse.RequestParser()
-        self.reqparse.add_argument(name='token',
-                                   type=str,
-                                   required=True,
-                                   default='',
-                                   help='missing SSO token from auth provider in post request')
-        self.reqparse.add_argument(name='userid', 
-                                   type=int, required=True, help='missing user ID')
-
-        super(UserDashboardAPI, self).__init__()
 
     def get(self):
-        args = self.reqparse.parse_args()
-        user_id = args['userid']
-        sso_token = args['token']
-
-        # verify credentials
-        api_key = request.headers.get('X-API-Key')
-        verify_api_key(api_key, config_name)
-        if config_name == 'production':
-            if not verify_token(sso_token):
-                abort(401, "no active login session found. please login to continue")
-
-        # get user details from the logged-in session
-        active_login_session = db.session.query(Sessions).filter(
-            Sessions.sso_token == sso_token).first()
-        if active_login_session.user_id != user_id:
-                abort(401, "cannot edit profile for another user")
-
-        # get user's personal information
-        user = db.session.query(User).filter(User.id == user_id).first()
+        verify_api_key(request)
+        login_session = verify_token(request)
 
         # artifacts owned by the logged-in user
         artifact_schema = ArtifactSchema(many=True, exclude=('meta', 'tags', 'files', 'affiliations', 'relationships'))
-        owned_artifacts = db.session.query(Artifact).filter(Artifact.owner_id == user.id)
+        owned_artifacts = db.session.query(Artifact).filter(Artifact.owner_id == login_session.user_id)
 
         response = jsonify({
             "user": UserSchema().dump(user),

--- a/searcch_backend/api/resources/importer.py
+++ b/searcch_backend/api/resources/importer.py
@@ -59,8 +59,7 @@ class ImporterResourceRoot(Resource):
         """
         Importers register via this endpoint.
         """
-        api_key = request.headers.get('X-Api-Key')
-        verify_api_key(api_key, config_name)
+        verify_api_key(request)
         
         args = self.post_reqparse.parse_args()
         if not args["url"] or not args["key"]:
@@ -100,8 +99,7 @@ class ImporterResourceRoot(Resource):
         """
         List all importer instances.
         """
-        api_key = request.headers.get('X-Api-Key')
-        verify_api_key(api_key, config_name)
+        verify_api_key(request)
         
         importer_instances = db.session.query(ImporterInstance).all()
         response = jsonify({"importers": importer_instances})
@@ -115,8 +113,7 @@ class ImporterResource(Resource):
         """
         Get an importer instance's details.
         """
-        api_key = request.headers.get('X-Api-Key')
-        verify_api_key(api_key, config_name)
+        verify_api_key(request)
         
         importer_instance = db.session.query(ImporterInstance).filter(
             ImporterInstance.id == importer_instance_id).first()
@@ -131,8 +128,7 @@ class ImporterResource(Resource):
         """
         Allows the importer to push its status to us.
         """
-        api_key = request.headers.get('X-Api-Key')
-        verify_api_key(api_key, config_name)
+        verify_api_key(request)
         
         importer_instance = db.session.query(ImporterInstance).filter(
             ImporterInstance.id == importer_instance_id).first()
@@ -163,8 +159,7 @@ class ImporterResource(Resource):
         # XXX: later on, need to validate this api key more tightly... only
         # admins and the instance itself should be allowed to delete, and then
         # only if not currently running.
-        api_key = request.headers.get('X-Api-Key')
-        verify_api_key(api_key, config_name)
+        verify_api_key(request)
         
         importer_instance = db.session.query(ImporterInstance).filter(
             ImporterInstance.id == importer_instance_id).first()

--- a/searcch_backend/models/model.py
+++ b/searcch_backend/models/model.py
@@ -445,6 +445,7 @@ class Sessions(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     sso_token = db.Column(db.String(64), nullable=False)
     expires_on = db.Column(db.DateTime, nullable=False)
+    user = db.relationship("User", uselist=False)
 
     def __repr__(self):
         return "<Session(id=%r, user_id=%r, sso_token='%s')>" \


### PR DESCRIPTION
… params.

This also removes several instances of conditionalizing token (user session)
checks only on the production path; this stuff has to be equivalent on the
dev path.

Remove all uses of SHARED_SECRET_PROD_KEY; nothing is setting this value;
just use SHARED_SECRET_KEY (for now).