### PR TITLE
Miscellaneous fixes for gunicorn startup.

### DIFF
--- a/env/gunicorn_conf.py
+++ b/env/gunicorn_conf.py
@@ -1,6 +1,4 @@
 import multiprocessing
-from searcch_backend.api.app import app
-from searcch_backend.api.common.scheduled_tasks import UpdateStatsViews
 
 bind = "0.0.0.0:80"
 workers = multiprocessing.cpu_count() * 2 + 1
@@ -17,13 +15,29 @@ enable_stdio_inheritance = True
 daemon = True
 
 #
+# NB: something in our import chain imports requests before the gevent worker
+# monkey patches requests.  So make sure it's done immediately.
+#
+if worker_class == "gevent":
+    import gevent
+    import gevent.monkey
+    gevent.monkey.patch_all()
+
+#
 # NB: early exceptions from the app may be lost when workers fail immediately.
 # Set preload_app = True if workers fail with no apparent cause; then you'll
 # see exceptions.
 #
 
-preload_app = True
+#preload_app = True
 
 def on_starting(server):
+    from searcch_backend.api.app import (app, db, migrate)
+    from searcch_backend.api.common.alembic import maybe_auto_upgrade_db
+    from searcch_backend.api.common.scheduled_tasks import UpdateStatsViews
+
+    # Run DB migrations
+    maybe_auto_upgrade_db(app, db, migrate)
+
     #Run Scheduler
-    UpdateStatsViews(interval_duration=app.config['STATS_GARBAGE_COLLECTOR_INTERVAL'])
+    UpdateStatsViews(app.config['STATS_GARBAGE_COLLECTOR_INTERVAL'])

--- a/env/gunicorn_conf_dev.py
+++ b/env/gunicorn_conf_dev.py
@@ -1,6 +1,4 @@
 import multiprocessing
-from searcch_backend.api.app import app
-from searcch_backend.api.common.scheduled_tasks import UpdateStatsViews
 
 bind = "0.0.0.0:80"
 workers = multiprocessing.cpu_count() * 2 + 1
@@ -17,13 +15,29 @@ enable_stdio_inheritance = True
 daemon = False
 
 #
+# NB: something in our import chain imports requests before the gevent worker
+# monkey patches requests.  So make sure it's done immediately.
+#
+if worker_class == "gevent":
+    import gevent
+    import gevent.monkey
+    gevent.monkey.patch_all()
+
+#
 # NB: early exceptions from the app may be lost when workers fail immediately.
 # Set preload_app = True if workers fail with no apparent cause; then you'll
 # see exceptions.
 #
 
-preload_app = True
+#preload_app = True
 
 def on_starting(server):
+    from searcch_backend.api.app import (app, db, migrate)
+    from searcch_backend.api.common.alembic import maybe_auto_upgrade_db
+    from searcch_backend.api.common.scheduled_tasks import UpdateStatsViews
+
+    # Run DB migrations
+    maybe_auto_upgrade_db(app, db, migrate)
+
     #Run Scheduler
-    UpdateStatsViews(interval_duration=app.config['STATS_GARBAGE_COLLECTOR_INTERVAL'])
+    UpdateStatsViews(app.config['STATS_GARBAGE_COLLECTOR_INTERVAL'])

--- a/searcch_backend/api/common/alembic.py
+++ b/searcch_backend/api/common/alembic.py
@@ -1,0 +1,33 @@
+
+def maybe_auto_upgrade_db(app, db, migrate, force=False):
+    if not force and "DB_AUTO_MIGRATE" not in app.config or not app.config["DB_AUTO_MIGRATE"]:
+        return
+
+    with app.app_context():
+        #
+        # All this work to safely auto-migrate in the presence of multiple
+        # processes.  NB: the table create is separated out due to racy table
+        # creation semantics in postgres:
+        # https://www.postgresql.org/message-id/CA+TgmoZAdYVtwBfp1FL2sMZbiHCWT4UPrzRLNnX1Nb30Ku3-gg@mail.gmail.com
+        #
+        import alembic
+        # First create the table (we don't have alembic_versions until later).
+        try:
+            db.session.execute("create table if not exists alembic_lock (locked boolean)")
+        except:
+            db.session.commit()
+        # Lock the table.
+        try:
+            db.session.execute("lock table alembic_lock in exclusive mode")
+        except:
+            app.logger.error("failed to lock before auto_migrate")
+            raise
+        # Migrate.
+        try:
+            alembic.command.upgrade(migrate.get_config(),"head")
+        except:
+            app.logger.error("failed to auto_migrate database; exiting")
+            raise
+        app.logger.info("auto_migrated database")
+        # Commit (unlock).
+        db.session.commit()


### PR DESCRIPTION
  * Force early monkey patch of gevent before on_starting hook (we have
    requests -> ssl deps, even early on, from api/resources/login);
  * move db auto migrate into on_starting;
  * fix minor bug with UpdateViewStats constructor interval_duration arg.