### PR TITLE
Backend Support to change Admin Privileges

### DIFF
--- a/searcch_backend/api/app.py
+++ b/searcch_backend/api/app.py
@@ -135,4 +135,4 @@ api.add_resource(BadgeResource, approot + '/badge/<int:badge_id>', endpoint='api
 api.add_resource(LicenseResourceRoot, approot + '/licenses', endpoint='api.licenses')
 api.add_resource(LicenseResource, approot + '/license/<int:org_id>', endpoint='api.license')
 
-api.add_resource(AdminUpdatePrivileges, approot + '/admin/update_privileges', endpoint='api.admin')
+api.add_resource(AdminUpdatePrivileges, approot + '/admin/user/<int:user_id>', endpoint='api.admin')

--- a/searcch_backend/api/app.py
+++ b/searcch_backend/api/app.py
@@ -76,7 +76,7 @@ from searcch_backend.api.resources.schema import (
     SchemaArtifactAPI, SchemaAffiliationAPI)
 from searcch_backend.api.resources.badge import BadgeResourceRoot, BadgeResource
 from searcch_backend.api.resources.license import LicenseResourceRoot, LicenseResource
-from searcch_backend.api.common.scheduled_tasks import UpdateStatsViews
+from searcch_backend.api.resources.admin import AdminUpdatePrivileges
 
 approot = app.config['APPLICATION_ROOT']
 
@@ -134,3 +134,5 @@ api.add_resource(BadgeResource, approot + '/badge/<int:badge_id>', endpoint='api
 
 api.add_resource(LicenseResourceRoot, approot + '/licenses', endpoint='api.licenses')
 api.add_resource(LicenseResource, approot + '/license/<int:org_id>', endpoint='api.license')
+
+api.add_resource(AdminUpdatePrivileges, approot + '/admin/update_privileges/<int:user_id>', endpoint='api.admin')

--- a/searcch_backend/api/app.py
+++ b/searcch_backend/api/app.py
@@ -135,4 +135,4 @@ api.add_resource(BadgeResource, approot + '/badge/<int:badge_id>', endpoint='api
 api.add_resource(LicenseResourceRoot, approot + '/licenses', endpoint='api.licenses')
 api.add_resource(LicenseResource, approot + '/license/<int:org_id>', endpoint='api.license')
 
-api.add_resource(AdminUpdatePrivileges, approot + '/admin/update_privileges/<int:user_id>', endpoint='api.admin')
+api.add_resource(AdminUpdatePrivileges, approot + '/admin/update_privileges', endpoint='api.admin')

--- a/searcch_backend/api/resources/admin.py
+++ b/searcch_backend/api/resources/admin.py
@@ -16,24 +16,17 @@ class AdminUpdatePrivileges(Resource):
         self.reqparse = reqparse.RequestParser()
         self.reqparse.add_argument(name='can_admin',
                                    type=str,
-                                   required=True,
+                                   required=False,
                                    default=None,
                                    help='admin privilege of user')
-        self.reqparse.add_argument(name='user_id',
-                                   type=int,
-                                   required=True,
-                                   default=None,
-                                   help='user_id of user to update')
-        
 
         super(AdminUpdatePrivileges, self).__init__()
     
-    def put(self):
+    def put(self, user_id):
         verify_api_key(request)
         login_session = verify_token(request)
         args = self.reqparse.parse_args()
         can_admin = args['can_admin']
-        user_id = args['user_id']
 
         # check if requesting user is an admin
         admin_user = db.session.query(User.can_admin)\
@@ -44,22 +37,25 @@ class AdminUpdatePrivileges(Resource):
         if not admin_user.can_admin:
             abort(400, description='requesting user is not an admin')
 
-        if can_admin is not None and user_id is not None:
-            # do not allow admin to modify their own admin privileges
-            if user_id == login_session.user_id:
-                abort(400, description='cannot modify your own admin privileges')
-            # update can_admin
-            user = db.session.query(User)\
-                .filter(User.id == user_id)\
-                .first()
-            if not user:
-                abort(400, description='invalid user_id')
-            user.can_admin = True if can_admin == 't' else False
-            db.session.commit()
-            response = jsonify({'message': 'admin privileges updated'})
+        response = jsonify({})
+
+        if user_id is not None:
+            if can_admin is not None:
+                # do not allow admin to modify their own admin privileges
+                if user_id == login_session.user_id:
+                    abort(400, description='cannot modify your own admin privileges')
+                # update can_admin
+                user = db.session.query(User)\
+                    .filter(User.id == user_id)\
+                    .first()
+                if not user:
+                    abort(400, description='invalid user_id')
+                user.can_admin = True if can_admin == 't' else False
+                db.session.commit()
+                response = jsonify({'message': 'admin privileges updated'})
         else:
             abort(400, description='invalid request')
-
+            
         response.headers.add('Access-Control-Allow-Origin', '*')
         response.status_code = 200
         return response

--- a/searcch_backend/api/resources/admin.py
+++ b/searcch_backend/api/resources/admin.py
@@ -1,0 +1,59 @@
+# logic for /admin
+
+from searcch_backend.api.app import db
+from searcch_backend.models.model import *
+from searcch_backend.models.schema import *
+from flask import abort, jsonify, request
+from flask_restful import reqparse, Resource
+from searcch_backend.api.common.auth import (verify_api_key, verify_token)
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+class AdminUpdatePrivileges(Resource):
+    def __init__(self):
+        self.reqparse = reqparse.RequestParser()
+        self.reqparse.add_argument(name='can_admin',
+                                   type=str,
+                                   required=False,
+                                   default=None,
+                                   help='admin privilege of user')
+        
+
+        super(AdminUpdatePrivileges, self).__init__()
+    
+    def put(self, user_id):
+        verify_api_key(request)
+        login_session = verify_token(request)
+        args = self.reqparse.parse_args()
+        can_admin = args['can_admin']
+
+        # check if requesting user is an admin
+        admin_user = db.session.query(User.can_admin)\
+            .filter(User.id == login_session.user_id)\
+            .first()
+        if not admin_user:
+            abort(400, description='invalid requesting user id')
+        if not admin_user.can_admin:
+            abort(400, description='requesting user is not an admin')
+
+        if can_admin is not None and user_id is not None:
+            # do not allow admin to modify their own admin privileges
+            if user_id == login_session.user_id:
+                abort(400, description='cannot modify your own admin privileges')
+            # update can_admin
+            user = db.session.query(User)\
+                .filter(User.id == user_id)\
+                .first()
+            if not user:
+                abort(400, description='invalid user_id')
+            user.can_admin = True if can_admin == 't' else False
+            db.session.commit()
+            response = jsonify({'message': 'admin privileges updated'})
+        else:
+            abort(400, description='invalid request')
+
+        response.headers.add('Access-Control-Allow-Origin', '*')
+        response.status_code = 200
+        return response

--- a/searcch_backend/api/resources/admin.py
+++ b/searcch_backend/api/resources/admin.py
@@ -16,18 +16,24 @@ class AdminUpdatePrivileges(Resource):
         self.reqparse = reqparse.RequestParser()
         self.reqparse.add_argument(name='can_admin',
                                    type=str,
-                                   required=False,
+                                   required=True,
                                    default=None,
                                    help='admin privilege of user')
+        self.reqparse.add_argument(name='user_id',
+                                   type=int,
+                                   required=True,
+                                   default=None,
+                                   help='user_id of user to update')
         
 
         super(AdminUpdatePrivileges, self).__init__()
     
-    def put(self, user_id):
+    def put(self):
         verify_api_key(request)
         login_session = verify_token(request)
         args = self.reqparse.parse_args()
         can_admin = args['can_admin']
+        user_id = args['user_id']
 
         # check if requesting user is an admin
         admin_user = db.session.query(User.can_admin)\


### PR DESCRIPTION
Added backend support to modify admin privileges using the frontend.

A `PUT` request has to be made to `/admin/update_privileges/<int:user_id>` in order to change the admin privilege of `user_id`.

The body of the put request must be of the form:
```
{
    can_admin: < { 't', 'f' } >,
    user_id: <user id of the user whose admin privileges need to be changed>
}
```

The following restrictions apply:
1. The admin isn't allowed to change their own admin privileges.
2. If the requesting user isn't an admin, the request does not go through.
3. If either the requesting user or the user_id (for which the admin privilege must be modified) doesn't exist in the database, the request does not go through.
4. If either the user_id or can_admin parameters aren't present in the request, the request fails.

Addresses the issue in https://github.com/ITI/searcch-backend/issues/59.